### PR TITLE
Allowing false/null/empty.. values in the options

### DIFF
--- a/source/tappable.js
+++ b/source/tappable.js
@@ -84,7 +84,7 @@
   w.tappable = function(selector, opts){
     if (typeof opts == 'function') opts = { onTap: opts };
     var options = {};
-    for (var key in defaults) options[key] = opts[key] || defaults[key];
+    for (var key in defaults) options[key] = typeof opts[key] !== "undefined" ? opts[key] : defaults[key];
     
     var el = options.containerElement,
       startTarget,


### PR DESCRIPTION
Hey,

I slightly modifed the way the options are initialized in order to be able to pass 0 or false values.

This is useful if you don't want to set an active class on tap for example. 
In my case, there were a couple times where I wanted the active class to be set on a parent of the taped element and not directly on it. 

By passing `activeClass: false` when creating the tappable object, I could then do what I want by adding/removing the class on my parent element in the `onStart`, `onEnd`, etc.. events.

What do you think? :)
