### PR TITLE
Fix for iOS4 text nodes do not trigger events

### DIFF
--- a/source/tappable.js
+++ b/source/tappable.js
@@ -43,7 +43,10 @@
     },
     getTarget = function(e){
       var el = e.target;
-      if (el) return el;
+      if (el) {
+        if (el.nodeType == 3) el = el.parentNode;
+        return el;
+      }
       var touch = e.targetTouches[0];
       return getTargetByCoords(touch.clientX, touch.clientY);
     },


### PR DESCRIPTION
In iOS4 text nodes do not trigger events, so we must set the target to the parent if it is a text node.
