### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The button is tapped when the finger is on top of the button, even after moving 
 Documentation
 -------------
 
-###Syntax
+### Syntax
 
 	tappable(selector, opts);
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
